### PR TITLE
doc: update README file to be coherent with other ODS repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
-[![](https://jitpack.io/v/Orange-OpenSource:ods-android.svg)](https://jitpack.io/#Orange-OpenSource:ods-android)
+<p align="center">
+  <a href="https://orange-opensource.github.io/ods-android">
+    <img src="https://c.woopic.com/logo-orange.png" alt="ODS Android" width="50" height="50">
+  </a>
+</p>
 
-# ods-android
+<h3 align="center">ODS Android</h3>
 
-Orange Design System Android components
-
-Check our documentation [here](https://Orange-OpenSource.github.io/ods-android).
+<p align="center">
+  ODS Android provides Orange Android components to developers and a demo application.
+  <br>
+  <a href="https://orange-opensource.github.io/ods-android"><strong>Visit ODS Android</strong></a>
+  <br>
+  <br>
+  <a href="https://github.com/Orange-OpenSource/ods-android/issues/new?assignees=B3nz01d&labels=bug%2Ctriage&template=bug_report.yml&title=%5BBug%5D%3A+Bug+Summary">Report bug</a>
+  ·
+  <a href="https://github.com/Orange-OpenSource/ods-android/issues/new?assignees=B3nz01d&labels=feature%2Ctriage&template=feature_request.yml&title=%5Bfeature%5D%3A+">Request feature</a>
+</p>


### PR DESCRIPTION
Note: I haven't kept `[![](https://jitpack.io/v/Orange-OpenSource:ods-android.svg)](https://jitpack.io/#Orange-OpenSource:ods-android)` because something's probably missing to display it.