### PR TITLE
[#205] Limit `demo-build-distribution` workflow to main 'ods-android' repository

### DIFF
--- a/.github/workflows/demo-build-distribution.yml
+++ b/.github/workflows/demo-build-distribution.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'Orange-OpenSource/ods-android'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Closes #205 

Tried to limit the execution of `demo-build-distribution` for this repo (and not for the forks).

Must check **after the merge** that it still works for the repo and that forks (e.g. https://github.com/julien-deramond/ods-android) don't received failed notifications anymore.