### PR TITLE
Remove Orange logo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-<p align="center">
-  <a href="https://orange-opensource.github.io/ods-android">
-    <img src="https://c.woopic.com/logo-orange.png" alt="ODS Android" width="50" height="50">
-  </a>
-</p>
-
-<h3 align="center">ODS Android</h3>
+<h1 align="center">ODS Android</h1>
 
 <p align="center">
   ODS Android provides Orange Android components to developers and a demo application.


### PR DESCRIPTION
Brand team requires that we have to remove the Orange logo from the `README.md` file.
Already done in Boosted (see https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap#readme)  and IoT Map Component.
I've removed the link as well since it is already below in "Visit ODS Android".

## [Live preview](https://github.com/Orange-OpenSource/ods-android/blob/fcdcf15d77a7d2dec456cfb8c2e1e8e0f25a625b/README.md)