### PR TITLE
Docs: Fix back to top issues

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -13,12 +13,6 @@
   </div>
 </footer>
 
-<nav aria-label="Back to top" class="back-to-top">
-  <a href="#top" class="back-to-top-link btn btn-icon btn-outline-secondary" data-bs-label="Back to top">
-    <span class="visually-hidden">Back to top</span>
-  </a>
-</nav>
-
 <script>
 /*!
 * Color mode toggler for Bootstrap's docs (https://getbootstrap.com/)

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -13,8 +13,6 @@
   </symbol>
 </svg>
 
-<a id="top"></a>
-
 <header class="sticky-top" data-bs-theme="dark">
   <div class="navbar navbar-expand-lg" aria-label="Global header of ODS Android">
     <div class="container-xxl">

--- a/docs/_includes/tarteaucitron.html
+++ b/docs/_includes/tarteaucitron.html
@@ -8,13 +8,13 @@
         padding: 1.25rem 0;
         background-color: var(--bs-body-bg);
         background-clip: padding-box;
+        border:var(--bs-border-width) solid var(--bs-border-color-subtle);
         transform: translateX(-50%)
     }
 
     [id="tarteaucitron"] [role="heading"] {
         display: block;
         font-weight: 700;
-        color: #000
     }
 
     @media (min-width: 480px) {
@@ -62,6 +62,7 @@
         font-weight: 700;
         color: #fff;
         background: #000;
+        border-top: var(--bs-border-width) solid var(--bs-border-color-subtle);
         --max-width: 312px
     }
 
@@ -105,22 +106,6 @@
         font-size: .875rem
     }
 
-    [id="tarteaucitronCloseAlert"] {
-        --bs-btn-color: #000;
-        --bs-btn-bg: #fff;
-        --bs-btn-border-color: #fff;
-        --bs-btn-hover-color: #fff;
-        --bs-btn-hover-bg: #000;
-        --bs-btn-hover-border-color: #000;
-        --bs-btn-focus-shadow-rgb: #fff;
-        --bs-btn-active-color: #000;
-        --bs-btn-active-bg: #ff7900;
-        --bs-btn-active-border-color: #ff7900;
-        --bs-btn-disabled-color: #ccc;
-        --bs-btn-disabled-bg: #fff;
-        --bs-btn-disabled-border-color: #ccc
-    }
-
     [id="tarteaucitronClosePanel"] {
         position: absolute;
         right: 1.25rem 0;
@@ -162,7 +147,7 @@
     }
 
     [id="tarteaucitronInfo"] {
-        padding: .625rem 1.25rem 0;
+        padding: .625rem 0;
         margin-bottom: 1.25rem;
         font-weight: 700
     }
@@ -190,7 +175,7 @@
     .tarteaucitronMainLine {
         padding-bottom: 1.25rem;
         margin-bottom: 1.25rem;
-        border-bottom: var(--bs-border-width) solid #ddd
+        border-bottom: var(--bs-border-width) solid var(--bs-border-color-subtle);
     }
 
     [id="tarteaucitronServices"] {
@@ -223,8 +208,8 @@
         min-height: inherit;
         content: "";
         background-color: currentcolor;
-        -webkit-mask: var(--o-check-icon) no-repeat 50% / .875rem .875rem;
-        mask: var(--o-check-icon) no-repeat 50% / .875rem .875rem
+        -webkit-mask: var(--bs-check-icon) no-repeat 50% / .875rem .875rem;
+        mask: var(--bs-check-icon) no-repeat 50% / .875rem .875rem
     }
 
     .tarteaucitronAllow::before {
@@ -242,8 +227,8 @@
         min-height: inherit;
         content: "";
         background-color: currentcolor;
-        -webkit-mask: var(--o-close-icon) no-repeat 50% / .875rem .875rem;
-        mask: var(--o-close-icon) no-repeat 50% / .875rem .875rem
+        -webkit-mask: var(--bs-close-icon) no-repeat 50% / .875rem .875rem;
+        mask: var(--bs-close-icon) no-repeat 50% / .875rem .875rem
     }
 
     .tarteaucitronDeny::before {
@@ -301,11 +286,13 @@
 
         window.addEventListener('tac.open_alert', () => {
             const alert = document.getElementById('tarteaucitronAlertBig')
+            
+            alert.setAttribute('data-bs-theme', 'dark')
 
-            document.getElementById('tarteaucitronCloseAlert').classList.add('btn', 'btn-sm', 'btn-info', 'btn-inverse', 'ms-lg-2')
-            alert.querySelector('.tarteaucitronAllow').classList.add('btn', 'btn-sm', 'btn-success', 'btn-inverse', 'mx-sm-2', 'ms-lg-auto', 'my-2', 'my-lg-0')
+            document.getElementById('tarteaucitronCloseAlert').classList.add('btn', 'btn-sm', 'btn-secondary', 'ms-lg-2')
+            alert.querySelector('.tarteaucitronAllow').classList.add('btn', 'btn-sm', 'btn-success', 'mx-sm-2', 'ms-lg-auto', 'my-2', 'my-lg-0')
             alert.querySelector('.tarteaucitronAllow').innerHTML = tarteaucitron.lang.acceptAll
-            alert.querySelector('.tarteaucitronDeny').classList.add('btn', 'btn-sm', 'btn-danger', 'btn-inverse', 'mx-sm-2', 'my-2', 'my-lg-0')
+            alert.querySelector('.tarteaucitronDeny').classList.add('btn', 'btn-sm', 'btn-danger', 'mx-sm-2', 'my-2', 'my-lg-0')
             alert.querySelector('.tarteaucitronDeny').innerHTML = tarteaucitron.lang.denyAll
         }, { once: true })
 

--- a/docs/_layouts/main.html
+++ b/docs/_layouts/main.html
@@ -22,6 +22,10 @@
         body {
             min-height: 100vh;
         }
+        body > .container-xxl,
+        body > .container-xxl > .row {
+            min-height: calc(100vh - 280px);
+        }
         img {
             max-width: 100%;
         }
@@ -42,9 +46,13 @@
 </head>
 
 <body>
+    {% if page.back-to-top != false %}
+    <a id="top"></a>
+    {% endif %}
+
     {% include header.html %}
 
-    <div class="container-xxl pt-4 pt-lg-5 mb-4 mb-lg-5">
+    <div class="container-xxl my-4 my-lg-5">
         <div class="row">
             
             <div class="col-lg-3" aria-label="Global navigation of ODS Android">
@@ -135,6 +143,14 @@
     </div>
 
     {% include footer.html %}
+
+    {% if page.back-to-top != false %}
+    <nav aria-label="Back to top" class="back-to-top">
+      <a href="#top" class="back-to-top-link btn btn-icon btn-outline-secondary" data-bs-label="Back to top">
+        <span class="visually-hidden">Back to top</span>
+      </a>
+    </nav>
+    {% endif %}
 
     {% include scripts.html %}
 

--- a/docs/_layouts/main.html
+++ b/docs/_layouts/main.html
@@ -22,10 +22,6 @@
         body {
             min-height: 100vh;
         }
-        body > .container-xxl,
-        body > .container-xxl > .row {
-            min-height: calc(100vh - 280px);
-        }
         img {
             max-width: 100%;
         }
@@ -38,6 +34,12 @@
         @media (max-width: 1023.98px) {
             .z-offcanvas {
                 z-index: 1045;
+            }
+        }
+        @media (min-width: 1024px) {
+            body > .container-xxl,
+            body > .container-xxl > .row {
+                min-height: calc(100vh - 280px);
             }
         }
     </style>

--- a/docs/about/Cookies_docs.md
+++ b/docs/about/Cookies_docs.md
@@ -2,4 +2,5 @@
 layout: main
 title: "Cookies"
 content_page: Cookies.md
+back-to-top: false
 ---

--- a/docs/about/License_docs.md
+++ b/docs/about/License_docs.md
@@ -2,4 +2,5 @@
 layout: main
 title: License
 content_page: License.md
+back-to-top: false
 ---

--- a/docs/about/Team_docs.md
+++ b/docs/about/Team_docs.md
@@ -2,4 +2,5 @@
 layout: main
 title: Team
 content_page: Team.md
+back-to-top: false
 ---

--- a/docs/components/AppBarsBottom_docs.md
+++ b/docs/components/AppBarsBottom_docs.md
@@ -2,4 +2,5 @@
 layout: main
 title: "App bars: bottom"
 content_page: AppBarsBottom.md
+back-to-top: false
 ---

--- a/docs/guidelines/Colors_docs.md
+++ b/docs/guidelines/Colors_docs.md
@@ -2,4 +2,5 @@
 layout: main
 title: Colors
 content_page: Colors.md
+back-to-top: false
 ---


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Following #808.

### Description

Remove Back to top component in best effort when the page is quite small.
Introducing `back-to-top` option for `*_docs.md` files.
Avoid the left menu having some issues when the page is too small.
Fix tarteaucitron display.

### Motivation & Context

When the page was too small, the back to top was introducing a small gray bar under the footer.
Icons weren't displayed well in tarteaucitron.

### Types of change

<!-- What types of changes does you code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines
- [x] My change is compatible with responsive display

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] Manually test on simulators and on a physical device (Android, orientation change, dark/light mode)
- [ ] Code review
- [ ] Design review
- [ ] A11y review